### PR TITLE
Update API JSON response for returning translations

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -11,16 +11,17 @@ class TranslationSerializers(serializers.ModelSerializer):
                   'frontCard',
                   'backCard'
                   ]
-        depth = 3
+        depth = 1
 
     def to_representation(self, instance):
         data = super().to_representation(instance)
         _id = data['i']
         frontCard = data['frontCard']
         backCard = data['backCard']
-        new = {'id': _id,
-               'frontCard': frontCard, 'backCard': backCard}
-        return new
+        updated_data = {'id': _id,
+                        'frontCard': frontCard,
+                        'backCard': backCard}
+        return updated_data
 
 
 class UserSerializer(serializers.HyperlinkedModelSerializer):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -18,25 +18,9 @@ class TranslationSerializers(serializers.ModelSerializer):
         _id = data['i']
         frontCard = data['frontCard']
         backCard = data['backCard']
-
-        # new_dict = {}
-        # new_dict['questions'] = {'id': _id,
-        #                          'frontCard': frontCard, 'backCard': backCard}
         new = {'id': _id,
                'frontCard': frontCard, 'backCard': backCard}
         return new
-
-
-# class TranslationSerializers(serializers.ModelSerializer):
-#     # items = serializers.ListField(child=HelperSerializers())
-#     cashflows = HelperSerializers(many=True, read_only=True)
-#     # id = HelperSerializers(many=True)
-
-    # def to_representation(self, instance):
-    #     response_dict = dict()
-    #     response_dict['questions'] = {
-    #     }
-    #     return response_dict
 
 
 class UserSerializer(serializers.HyperlinkedModelSerializer):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -19,10 +19,18 @@ class TranslationSerializers(serializers.ModelSerializer):
         frontCard = data['frontCard']
         backCard = data['backCard']
 
-        new_dict = {}
-        new_dict['questions'] = {'id': _id,
-                                 'frontCard': frontCard, 'backCard': backCard}
-        return new_dict
+        # new_dict = {}
+        # new_dict['questions'] = {'id': _id,
+        #                          'frontCard': frontCard, 'backCard': backCard}
+        new = {'id': _id,
+               'frontCard': frontCard, 'backCard': backCard}
+        return new
+
+
+# class TranslationSerializers(serializers.ModelSerializer):
+#     # items = serializers.ListField(child=HelperSerializers())
+#     cashflows = HelperSerializers(many=True, read_only=True)
+#     # id = HelperSerializers(many=True)
 
     # def to_representation(self, instance):
     #     response_dict = dict()

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -15,8 +15,13 @@ class TranslationSerializers(serializers.ModelSerializer):
 
     def to_representation(self, instance):
         data = super().to_representation(instance)
+        _id = data['i']
+        frontCard = data['frontCard']
+        backCard = data['backCard']
+
         new_dict = {}
-        new_dict['questions'] = data
+        new_dict['questions'] = {'id': _id,
+                                 'frontCard': frontCard, 'backCard': backCard}
         return new_dict
 
     # def to_representation(self, instance):

--- a/api/views.py
+++ b/api/views.py
@@ -17,7 +17,9 @@ class APIGetTranslations(TemplateView):
     def get(self, request):
         translation = Translation.objects.all()
         serializer = TranslationSerializers(translation, many=True)
-        return JsonResponse(serializer.data,
+        new_dict = {}
+        new_dict['questions'] = serializer.data
+        return JsonResponse(new_dict,
                             safe=False,
                             json_dumps_params={'indent': 4})
 

--- a/api/views.py
+++ b/api/views.py
@@ -12,31 +12,32 @@ from rest_framework import permissions
 
 
 class APIGetTranslations(TemplateView):
+
     model = Translation
 
     def get(self, request):
         translation = Translation.objects.all()
-        serializer = TranslationSerializers(translation, many=True)
-        new_dict = {}
-        new_dict['questions'] = serializer.data
-        return JsonResponse(new_dict,
+        raw_serializer = TranslationSerializers(translation, many=True)
+        serializer_data = {}
+        serializer_data['questions'] = raw_serializer.data
+        return JsonResponse(serializer_data,
                             safe=False,
                             json_dumps_params={'indent': 4})
 
 
 class UserViewSet(viewsets.ModelViewSet):
-    """
+    '''
     API endpoint that allows users to be viewed or edited.
-    """
+    '''
     queryset = User.objects.all().order_by('-date_joined')
     serializer_class = UserSerializer
     permission_classes = [permissions.IsAuthenticated]
 
 
 class GroupViewSet(viewsets.ModelViewSet):
-    """
+    '''
     API endpoint that allows groups to be viewed or edited.
-    """
+    '''
     queryset = Group.objects.all()
     serializer_class = GroupSerializer
     permission_classes = [permissions.IsAuthenticated]


### PR DESCRIPTION
So the idea is to modify the `/translations` response to receive something like that 


```bash
{
    "questions": [
        {
            "id": 1,
            "frontCard": "proctors",
            "backCard": "opiekunowie"
        },
        {
            "id": 2,
            "frontCard": "museum",
            "backCard": "muzeum"
        }
]
```

instead of 

```bash
[
    {
        "i": 1,
        "frontCard": "proctors",
        "backCard": "opiekunowie"
    },
    {
        "i": 2,
        "frontCard": "museum",
        "backCard": "muzeum"
    }
]
```