### PR TITLE
Add 'target language' and 'name' to Available Languages List

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -32,17 +32,27 @@ class AvailableLanguagesViewSet(viewsets.ModelViewSet):
     queryset = Language.objects.all()
     serializer_class = AvailableLanguagesSerializers
 
+    # ISO 639-1 code has always lenght of 2
+    length = 2
+
     # def retrieve(self, request, *args, **kwargs):
     #     return Response({'something': 'my custom JSON'})
 
     def list(self, request, *args, **kwargs):
-        languages = Language.objects.all()
-        serializers = self.get_serializer(languages, many=True)
+        from iso639 import languages
+
+        languages_objects = Language.objects.all()
+        serializers = self.get_serializer(languages_objects, many=True)
         conversions_list = []
         for id, item in enumerate(serializers.data):
             conversion = {}
+            iso639_lang_code = item['conversion'][self.length+1:]
+            language_name = languages.get(part1=str(iso639_lang_code)).name
+
             conversion['id'] = id
             conversion['conversion'] = item['conversion']
+            conversion['target_language'] = iso639_lang_code
+            conversion['name'] = language_name
             conversions_list.append(conversion)
 
         return Response({'available_conversions': conversions_list})


### PR DESCRIPTION
The idea of this PR is to have a JSON response like this

```JSON
{
    "available_conversions": [
        {
            "id": 0,
            "conversion": "en-pl",
            "target_language": "pl",
            "name": "Polish"
        },
        {
            "id": 1,
            "conversion": "en-de",
            "target_language": "de",
            "name": "German"
        },
        {
            "id": 2,
            "conversion": "en-fr",
            "target_language": "fr",
            "name": "French"
        },
        {
            "id": 3,
            "conversion": "en-es",
            "target_language": "es",
            "name": "Spanish"
        },
        {
            "id": 4,
            "conversion": "en-ru",
            "target_language": "ru",
            "name": "Russian"
        },
        {
            "id": 5,
            "conversion": "en-it",
            "target_language": "it",
            "name": "Italian"
        },
        {
            "id": 6,
            "conversion": "en-sv",
            "target_language": "sv",
            "name": "Swedish"
        },
        {
            "id": 7,
            "conversion": "en-zh",
            "target_language": "zh",
            "name": "Chinese"
        }
    ]
}
```

meaning that two new fields were added, namely `target_languages` and `name`